### PR TITLE
Add tonic tracking and root update logic

### DIFF
--- a/frontend/src/components/IntegratedMusicSidebar.tsx
+++ b/frontend/src/components/IntegratedMusicSidebar.tsx
@@ -138,6 +138,7 @@ const IntegratedMusicSidebar: React.FC<IntegratedMusicSidebarProps> = ({
     if (state.notesHistory.length > 0) {
       const lowest = Math.min(...state.notesHistory);
       const result = modeDetector.setRootPitch(lowest);
+      modeDetector.unlockRootOverride();
       setModeDetectionResult(result);
       setRootPitch(lowest);
     }
@@ -844,9 +845,8 @@ const IntegratedMusicSidebar: React.FC<IntegratedMusicSidebarProps> = ({
       const latestNote = midiData.playedNotes[midiData.playedNotes.length - 1];
       if (latestNote) {
         const pitchClass = latestNote.number % 12;
-        const midiNumber = latestNote.number;
         console.log('🎵 Adding note to real-time detector:', pitchClass);
-        const newResult = modeDetector.addNote(pitchClass, midiNumber);
+        const newResult = modeDetector.addNote(latestNote.number, pitchClass);
         // Only update state if we got a valid result (not null for duplicate notes)
         if (newResult !== null) {
           currentResult = newResult;

--- a/frontend/tests/unit/services/realTimeModeDetection.test.ts
+++ b/frontend/tests/unit/services/realTimeModeDetection.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { RealTimeModeDetector } from '@/services/realTimeModeDetection';
+import { A4, C5, C4 } from '@fixtures/musical-data';
+
+// Pitch classes
+const PC_A = A4 % 12;
+const PC_C = C5 % 12;
+const PC_C_LOW = C4 % 12;
+
+describe('RealTimeModeDetector root handling', () => {
+  it('keeps root when higher octave notes have lower pitch classes', () => {
+    const detector = new RealTimeModeDetector();
+
+    detector.addNote(A4, PC_A); // first note sets root to A
+    let state = detector.getState();
+    expect(state.rootPitch).toBe(PC_A);
+
+    detector.addNote(C5, PC_C); // higher note with smaller pitch class
+    state = detector.getState();
+    expect(state.rootPitch).toBe(PC_A); // root should remain A
+
+    detector.addNote(C4, PC_C_LOW); // lower note
+    state = detector.getState();
+    expect(state.rootPitch).toBe(PC_C_LOW); // root updates to C
+  });
+});


### PR DESCRIPTION
## Summary
- store `lowestMidiNote` in `RealTimeModeDetector`
- expose `unlockRootOverride` and track manual tonic overrides
- update note processing to take a MIDI note and pitch class
- update sidebar to pass MIDI note and allow unlocking
- add regression test for tonic tracking logic

## Testing
- `npm run test:unit` *(fails: RealTimeModeDetector root handling > keeps root when higher octave notes have lower pitch classes)*

------
https://chatgpt.com/codex/tasks/task_e_6881331f9ce48324aef5607588ff1863