### PR TITLE
Add mode note lists to suggestions

### DIFF
--- a/frontend/src/components/IntegratedMusicSidebar.tsx
+++ b/frontend/src/components/IntegratedMusicSidebar.tsx
@@ -224,23 +224,23 @@ const IntegratedMusicSidebar: React.FC<IntegratedMusicSidebarProps> = ({
                   <div key={`${family}-${index}`} className="suggestion-item">
                     <div className="suggestion-header">
                       <span className="suggestion-name">• {suggestion.fullName}</span>
+                      <span className="suggestion-notes"> {suggestion.notes.join(' ')}</span>
                       <span className="suggestion-mismatch">
                         [{suggestion.mismatchCount} {suggestion.mismatchCount === 1 ? 'mismatch' : 'mismatches'}]
                       </span>
                     </div>
                     {onSwitchToReferenceWithHighlight && (
                       <button
-                        className="preview-btn"
+                        className="preview-btn preview-link"
                         onClick={() => {
                           const parts = suggestion.fullName.split(' ');
                           const tonic = parts[0];
                           const mode = parts.slice(1).join(' ');
                           onSwitchToReferenceWithHighlight(mode, tonic);
                         }}
-                        aria-label={`Preview ${suggestion.fullName} scale`}
-                        title="👁️ Preview scale"
+                        aria-label={`View ${suggestion.fullName} scale`}
                       >
-                        👁️
+                        View
                       </button>
                     )}
                   </div>

--- a/frontend/src/services/realTimeModeDetection.ts
+++ b/frontend/src/services/realTimeModeDetection.ts
@@ -89,11 +89,12 @@ const MODE_ORDER: Record<ScaleFamily, string[]> = Object.fromEntries(
   })
 ) as Record<ScaleFamily, string[]>;
 
-// Note names for display - using proper enharmonic spellings from legacy system
+// Note names for display - prefer spellings used in scale tables
 const buildNoteNames = (): string[] => {
   const noteNames: string[] = [];
   for (let i = 0; i < 12; i++) {
-    noteNames[i] = PARENT_KEYS[i as keyof typeof PARENT_KEYS];
+    const entry = PITCH_CLASS_NAMES[i as keyof typeof PITCH_CLASS_NAMES];
+    noteNames[i] = entry?.normal ?? PARENT_KEYS[i as keyof typeof PARENT_KEYS];
   }
   return noteNames;
 };

--- a/frontend/src/services/realTimeModeDetection.ts
+++ b/frontend/src/services/realTimeModeDetection.ts
@@ -40,6 +40,7 @@ export interface ModeSuggestion {
   mismatchCount: number;
   matchCount: number;
   popularity: number;
+  notes: string[];
 }
 
 // Scale family definitions from legacy system (constants/scales.ts)
@@ -337,13 +338,20 @@ export class RealTimeModeDetector {
       
       // Only include modes that have at least some matches
       if (matchCount > 0) {
+        const root = mode.actualRoot ?? this.state.rootPitch!;
+        const familyData = allScaleData.find(s => s.name === mode.family);
+        const notes = familyData
+          ? familyData.modeIntervals[mode.modeIndex].map(i => NOTE_NAMES[(root + i) % 12])
+          : Array.from(mode.modePitchSet).map(pc => NOTE_NAMES[pc]).sort();
+
         const suggestion: ModeSuggestion = {
           family: mode.family,
           name: mode.name,
-          fullName: `${NOTE_NAMES[mode.actualRoot ?? this.state.rootPitch!]} ${mode.name}`,
+          fullName: `${NOTE_NAMES[root]} ${mode.name}`,
           matchCount,
           mismatchCount,
-          popularity: mode.popularity
+          popularity: mode.popularity,
+          notes
         };
         
         if (!familyGroups.has(mode.family)) {
@@ -403,14 +411,21 @@ export class RealTimeModeDetector {
     for (const mode of this.state.candidateModes) {
       const matchCount = this.calculateMatchCount(notesHistorySet, mode.modePitchSet);
       const mismatchCount = this.calculateMismatchCount(notesHistorySet, mode.modePitchSet);
-      
+
+      const root = mode.actualRoot ?? this.state.rootPitch!;
+      const familyData = allScaleData.find(s => s.name === mode.family);
+      const notes = familyData
+        ? familyData.modeIntervals[mode.modeIndex].map(i => NOTE_NAMES[(root + i) % 12])
+        : Array.from(mode.modePitchSet).map(pc => NOTE_NAMES[pc]).sort();
+
       const suggestion: ModeSuggestion = {
         family: mode.family,
         name: mode.name,
-        fullName: `${NOTE_NAMES[mode.actualRoot ?? this.state.rootPitch!]} ${mode.name}`,
+        fullName: `${NOTE_NAMES[root]} ${mode.name}`,
         matchCount,
         mismatchCount,
-        popularity: mode.popularity
+        popularity: mode.popularity,
+        notes
       };
       
       if (!familyGroups.has(mode.family)) {


### PR DESCRIPTION
## Summary
- include `notes` array in `ModeSuggestion`
- compute note names from mode pitch sets
- display notes with each suggestion
- update preview button to text link

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_688148139a908324855fce97bed1331a