### PR TITLE
Track lowest pitch for root updates

### DIFF
--- a/frontend/tests/unit/services/realTimeModeDetection.test.ts
+++ b/frontend/tests/unit/services/realTimeModeDetection.test.ts
@@ -8,19 +8,22 @@ const PC_C = C5 % 12;
 const PC_C_LOW = C4 % 12;
 
 describe('RealTimeModeDetector root handling', () => {
-  it('keeps root when higher octave notes have lower pitch classes', () => {
+  it('defaults rootPitch to the lowest pitch class', () => {
     const detector = new RealTimeModeDetector();
 
     detector.addNote(A4, PC_A); // first note sets root to A
     let state = detector.getState();
     expect(state.rootPitch).toBe(PC_A);
+    expect(state.lowestPitch).toBe(PC_A);
 
-    detector.addNote(C5, PC_C); // higher note with smaller pitch class
+    detector.addNote(C5, PC_C); // higher octave note with lower pitch class
     state = detector.getState();
-    expect(state.rootPitch).toBe(PC_A); // root should remain A
+    expect(state.rootPitch).toBe(PC_C); // root updates to C
+    expect(state.lowestPitch).toBe(PC_C);
 
-    detector.addNote(C4, PC_C_LOW); // lower note
+    detector.addNote(C4, PC_C_LOW); // lower note same pitch class
     state = detector.getState();
-    expect(state.rootPitch).toBe(PC_A); // root remains A
+    expect(state.rootPitch).toBe(PC_C); // root stays C
+    expect(state.lowestPitch).toBe(PC_C);
   });
 });


### PR DESCRIPTION
## Summary
- track a `lowestPitch` value in `RealTimeModeDetector`
- update this lowest pitch in `addNote`
- use `lowestPitch` for the default `rootPitch`
- adjust unit test for new behaviour

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68815284d3648324942385d69aab1752