### PR TITLE
Remove sidebar reset button

### DIFF
--- a/frontend/src/components/IntegratedMusicSidebar.tsx
+++ b/frontend/src/components/IntegratedMusicSidebar.tsx
@@ -64,7 +64,6 @@ const IntegratedMusicSidebar: React.FC<IntegratedMusicSidebarProps> = ({
   const [modeDetector] = useState(() => new RealTimeModeDetector());
   const [modeDetectionResult, setModeDetectionResult] = useState<ModeDetectionResult | null>(null);
   const [rootPitch, setRootPitch] = useState<number | null>(null);
-  const [rootLocked, setRootLocked] = useState(false);
   const [notesHistory, setNotesHistory] = useState<number[]>([]);
   
   // Progressive disclosure state management
@@ -117,20 +116,6 @@ const IntegratedMusicSidebar: React.FC<IntegratedMusicSidebarProps> = ({
     const result = modeDetector.setRootPitch(pitchClass);
     setModeDetectionResult(result);
     setRootPitch(pitchClass);
-    setRootLocked(true);
-  };
-
-  const handleResetRoot = () => {
-    const state = modeDetector.getState();
-    if (state.notesHistory.length > 0) {
-      const lowest = Math.min(...state.notesHistory);
-      const result = modeDetector.setRootPitch(lowest);
-      modeDetector.unlockRootOverride();
-      setModeDetectionResult(result);
-      setRootPitch(lowest);
-    }
-    setRootLocked(false);
-    trackInteraction('Root Reset - Reset to Lowest Note', 'Music Analysis');
   };
 
 
@@ -761,15 +746,7 @@ const IntegratedMusicSidebar: React.FC<IntegratedMusicSidebarProps> = ({
       }
 
       const state = modeDetector.getState();
-      if (rootLocked) {
-        if (rootPitch !== null && state.rootPitch !== rootPitch) {
-          const override = modeDetector.setRootPitch(rootPitch);
-          currentResult = override;
-          setModeDetectionResult(currentResult);
-        }
-      } else {
-        setRootPitch(state.rootPitch);
-      }
+      setRootPitch(state.rootPitch);
       setNotesHistory(state.notesHistory);
 
       // Adaptive view mode based on note count and mode state
@@ -886,8 +863,6 @@ const IntegratedMusicSidebar: React.FC<IntegratedMusicSidebarProps> = ({
                   className="sidebar-midi-panel"
                   currentRoot={rootPitch}
                   onRootSelect={handleSetRootPitch}
-                  onResetRoot={handleResetRoot}
-                  rootLocked={rootLocked}
                   historyPitchClasses={notesHistory}
                 />
               </div>

--- a/frontend/src/components/MidiDetectionPanel.tsx
+++ b/frontend/src/components/MidiDetectionPanel.tsx
@@ -14,8 +14,6 @@ interface MidiDetectionPanelProps {
   className?: string;
   currentRoot?: number | null;
   onRootSelect?: (pitchClass: number) => void;
-  onResetRoot?: () => void;
-  rootLocked?: boolean;
   historyPitchClasses?: number[];
 }
 
@@ -25,8 +23,6 @@ const MidiDetectionPanel: React.FC<MidiDetectionPanelProps> = ({
   className = '',
   currentRoot,
   onRootSelect,
-  onResetRoot,
-  rootLocked = false,
   historyPitchClasses = []
 }) => {
   const [processedScales, setProcessedScales] = React.useState<ProcessedScale[]>([]);
@@ -178,14 +174,6 @@ const MidiDetectionPanel: React.FC<MidiDetectionPanelProps> = ({
                       </button>
                     );
                   }))}
-                {rootLocked && (
-                  <button
-                    onClick={onResetRoot}
-                    className="ml-1 px-1.5 py-0.5 rounded bg-slate-600 hover:bg-slate-500"
-                  >
-                    Reset to Lowest Note
-                  </button>
-                )}
               </>
             ) : (
               'No notes detected'


### PR DESCRIPTION
## Summary
- remove root reset logic from IntegratedMusicSidebar
- drop Reset UI from MidiDetectionPanel

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881b9ef0be08324985b15503ad58e32