### PR TITLE
Add sidebar snapshots and mode detection tests

### DIFF
--- a/frontend/tests/component/sidebar/__snapshots__/simplified-sidebar.test.tsx.snap
+++ b/frontend/tests/component/sidebar/__snapshots__/simplified-sidebar.test.tsx.snap
@@ -1,0 +1,124 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`IntegratedMusicSidebar snapshots > renders collapsed sidebar 1`] = `
+<div>
+  <button
+    aria-label="Show music analysis sidebar"
+    class="sidebar-toggle-btn"
+    style="position: fixed; right: 20px; top: 50%; transform: translateY(-50%); z-index: 1001; background: rgb(71, 85, 105); color: rgb(226, 232, 240); border-radius: 8px 0 0 8px; padding: 12px 8px; cursor: pointer; transition: all 0.3s ease; font-size: 1.2rem; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);"
+  >
+    🎵
+  </button>
+</div>
+`;
+
+exports[`IntegratedMusicSidebar snapshots > renders expanded empty sidebar 1`] = `
+<div>
+  <button
+    aria-label="Hide music analysis sidebar"
+    class="sidebar-toggle-btn"
+    style="position: fixed; right: 320px; top: 50%; transform: translateY(-50%); z-index: 1001; background: rgb(71, 85, 105); color: rgb(226, 232, 240); border-radius: 8px 0 0 8px; padding: 12px 8px; cursor: pointer; transition: all 0.3s ease; font-size: 1.2rem; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);"
+  >
+    →
+  </button>
+  <div
+    class="integrated-music-sidebar "
+  >
+    <div
+      class="sidebar-section"
+    >
+      <div
+        class="sidebar-section-header"
+      >
+        <h3
+          class="sidebar-section-title"
+        >
+          <span
+            class="sidebar-status-indicator inactive"
+          />
+          🎹 Live Input Analysis
+        </h3>
+        <button
+          class="sidebar-section-toggle"
+        >
+          −
+        </button>
+      </div>
+      <div
+        class="sidebar-section-content"
+      >
+        <div
+          class="midi-detection-panel sidebar-midi-panel"
+        >
+          <div
+            class="midi-detection-card"
+          >
+            <h3
+              class="text-xs font-semibold mb-2 text-cyan-400"
+            >
+              Live Input Analysis
+            </h3>
+            <div
+              class="mb-0"
+            >
+              <div
+                class="flex justify-between items-center mb-1"
+              >
+                <p
+                  class="text-xs font-medium"
+                >
+                  Notes Detected:
+                </p>
+                <div
+                  class="flex gap-1"
+                >
+                  <button
+                    class="px-1.5 py-0.5 text-xs bg-slate-600 hover:bg-slate-500 rounded transition-colors"
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+              <div
+                class="min-h-[18px] p-1.5 bg-slate-800 rounded text-xs font-mono flex flex-wrap gap-1 items-center"
+              >
+                No notes detected
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="sidebar-section"
+    >
+      <div
+        class="sidebar-section-header"
+      >
+        <h3
+          class="sidebar-section-title"
+        >
+          <span
+            class="sidebar-status-indicator inactive"
+          />
+          🎯 Musical Analysis
+        </h3>
+        <button
+          class="sidebar-section-toggle"
+        >
+          −
+        </button>
+      </div>
+      <div
+        class="sidebar-section-content"
+      >
+        <div
+          class="no-results"
+        >
+          Play some notes to see analysis
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/tests/component/sidebar/simplified-sidebar.test.tsx
+++ b/frontend/tests/component/sidebar/simplified-sidebar.test.tsx
@@ -1,0 +1,18 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import IntegratedMusicSidebar from '@/components/IntegratedMusicSidebar';
+
+/** Snapshot tests for minimal sidebar rendering */
+
+describe('IntegratedMusicSidebar snapshots', () => {
+  it('renders collapsed sidebar', () => {
+    const { container } = render(<IntegratedMusicSidebar />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders expanded empty sidebar', () => {
+    const { container, getByLabelText } = render(<IntegratedMusicSidebar />);
+    fireEvent.click(getByLabelText('Show music analysis sidebar'));
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/tests/unit/services/realTimeModeDetection.test.ts
+++ b/frontend/tests/unit/services/realTimeModeDetection.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { RealTimeModeDetector } from '@/services/realTimeModeDetection';
-import { A4, C5, C4 } from '@fixtures/musical-data';
+import {
+  A4,
+  C5,
+  C4,
+  CSharp4,
+  FSharp4,
+  F4,
+  E4,
+  B3,
+  B4
+} from '@fixtures/musical-data';
+import { MODE_TO_INDEX_MAPPINGS } from '@/constants/mappings';
 
 // Pitch classes
 const PC_A = A4 % 12;
@@ -25,5 +36,44 @@ describe('RealTimeModeDetector root handling', () => {
     state = detector.getState();
     expect(state.rootPitch).toBe(PC_C); // root stays C
     expect(state.lowestPitch).toBe(PC_C);
+  });
+});
+
+describe('RealTimeModeDetector suggestion ordering', () => {
+  it('returns suggestions following MODE_TO_INDEX_MAPPINGS order', () => {
+    const detector = new RealTimeModeDetector();
+    const result = detector.addNote(C4, PC_C_LOW)!;
+    // Extract Major Scale ordering from mapping
+    const majorMapping = Object.entries(MODE_TO_INDEX_MAPPINGS['Major Scale']).sort((a,b) => a[1]-b[1]).map(([name]) => name);
+    const majorSuggestions = result.suggestions.filter(s => s.family === 'Major Scale').map(s => s.name);
+    expect(majorSuggestions).toEqual(majorMapping.slice(0, majorSuggestions.length));
+  });
+});
+
+describe('RealTimeModeDetector mismatch handling', () => {
+  it('preserves mismatch counts for partial matches', () => {
+    const detector = new RealTimeModeDetector();
+    detector.addNote(C4, 0);
+    detector.addNote(CSharp4, 1);
+    detector.addNote(FSharp4, 6);
+    detector.addNote(F4, 5);
+    const result = detector.addNote(B4, 11)!;
+    expect(result.suggestions.length).toBeGreaterThan(0);
+    const first = result.suggestions[0];
+    expect(first.mismatchCount).toBeGreaterThan(0);
+  });
+});
+
+describe('RealTimeModeDetector manual tonic override', () => {
+  it('setRootPitch locks the root despite lower notes', () => {
+    const detector = new RealTimeModeDetector();
+    detector.addNote(E4, 4);
+    detector.addNote(C4, 0); // lowest note sets root to C
+    detector.setRootPitch(4); // user selects E
+    let state = detector.getState();
+    expect(state.rootPitch).toBe(4);
+    detector.addNote(B3, 11); // lower pitch class
+    state = detector.getState();
+    expect(state.rootPitch).toBe(4); // still E
   });
 });


### PR DESCRIPTION
## Summary
- extend real-time mode detection tests
- verify suggestion ordering and mismatch handling
- test manual tonic override
- snapshot IntegratedMusicSidebar in collapsed/expanded states

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68823461db1c8324aba56be9364efec0